### PR TITLE
Issue 217 rename event structs

### DIFF
--- a/QminderAPI.podspec
+++ b/QminderAPI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'QminderAPI'
-  s.version          = '1.6.4'
+  s.version          = '1.7.0'
   s.summary          = 'Qminder iOS API'
 
   s.description      = <<-DESC

--- a/QminderAPI.xcodeproj/project.pbxproj
+++ b/QminderAPI.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		6320D848204D81420041FFAC /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63520649204D78E5008C8C54 /* Extensions.swift */; };
 		6320D849204D81420041FFAC /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064A204D78E5008C8C54 /* HTTPMethod.swift */; };
 		6320D84A204D81440041FFAC /* QminderEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064C204D78E5008C8C54 /* QminderEvents.swift */; };
-		6320D84B204D81440041FFAC /* QminderEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064D204D78E5008C8C54 /* QminderEvent.swift */; };
+		6320D84B204D81440041FFAC /* QminderWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064D204D78E5008C8C54 /* QminderWebsocketEvent.swift */; };
 		6320D84C204D81480041FFAC /* EventResponsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064F204D78E5008C8C54 /* EventResponsable.swift */; };
 		6320D84D204D81480041FFAC /* LinesEventResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63520650204D78E5008C8C54 /* LinesEventResponse.swift */; };
 		6320D84E204D81480041FFAC /* DeviceEventResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63520651204D78E5008C8C54 /* DeviceEventResponse.swift */; };
@@ -133,11 +133,11 @@
 		635206F2204D7A3F008C8C54 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63520649204D78E5008C8C54 /* Extensions.swift */; };
 		635206F3204D7A3F008C8C54 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064A204D78E5008C8C54 /* HTTPMethod.swift */; };
 		635206F4204D7A43008C8C54 /* QminderEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064C204D78E5008C8C54 /* QminderEvents.swift */; };
-		635206F5204D7A43008C8C54 /* QminderEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064D204D78E5008C8C54 /* QminderEvent.swift */; };
+		635206F5204D7A43008C8C54 /* QminderWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064D204D78E5008C8C54 /* QminderWebsocketEvent.swift */; };
 		635206F6204D7A43008C8C54 /* QminderEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064C204D78E5008C8C54 /* QminderEvents.swift */; };
-		635206F7204D7A43008C8C54 /* QminderEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064D204D78E5008C8C54 /* QminderEvent.swift */; };
+		635206F7204D7A43008C8C54 /* QminderWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064D204D78E5008C8C54 /* QminderWebsocketEvent.swift */; };
 		635206F8204D7A43008C8C54 /* QminderEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064C204D78E5008C8C54 /* QminderEvents.swift */; };
-		635206F9204D7A43008C8C54 /* QminderEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064D204D78E5008C8C54 /* QminderEvent.swift */; };
+		635206F9204D7A43008C8C54 /* QminderWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6352064D204D78E5008C8C54 /* QminderWebsocketEvent.swift */; };
 		635206FA204D7A46008C8C54 /* QminderEventsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63520653204D78E5008C8C54 /* QminderEventsDelegate.swift */; };
 		635206FB204D7A46008C8C54 /* QminderEventsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63520653204D78E5008C8C54 /* QminderEventsDelegate.swift */; };
 		635206FC204D7A47008C8C54 /* QminderEventsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63520653204D78E5008C8C54 /* QminderEventsDelegate.swift */; };
@@ -195,18 +195,18 @@
 		63AFBA9D20D00A0D009E3D1C /* Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBA9B20D00A0D009E3D1C /* Callback.swift */; };
 		63AFBA9E20D00A0D009E3D1C /* Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBA9B20D00A0D009E3D1C /* Callback.swift */; };
 		63AFBA9F20D00A0D009E3D1C /* Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBA9B20D00A0D009E3D1C /* Callback.swift */; };
-		63AFBAA120D0FC21009E3D1C /* TicketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA020D0FC21009E3D1C /* TicketEvent.swift */; };
-		63AFBAA220D0FC21009E3D1C /* TicketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA020D0FC21009E3D1C /* TicketEvent.swift */; };
-		63AFBAA320D0FC21009E3D1C /* TicketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA020D0FC21009E3D1C /* TicketEvent.swift */; };
-		63AFBAA420D0FC21009E3D1C /* TicketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA020D0FC21009E3D1C /* TicketEvent.swift */; };
-		63AFBAA620D0FC42009E3D1C /* DeviceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA520D0FC42009E3D1C /* DeviceEvent.swift */; };
-		63AFBAA720D0FC42009E3D1C /* DeviceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA520D0FC42009E3D1C /* DeviceEvent.swift */; };
-		63AFBAA820D0FC42009E3D1C /* DeviceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA520D0FC42009E3D1C /* DeviceEvent.swift */; };
-		63AFBAA920D0FC42009E3D1C /* DeviceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA520D0FC42009E3D1C /* DeviceEvent.swift */; };
-		63AFBAAB20D0FC54009E3D1C /* LineEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAAA20D0FC54009E3D1C /* LineEvent.swift */; };
-		63AFBAAC20D0FC54009E3D1C /* LineEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAAA20D0FC54009E3D1C /* LineEvent.swift */; };
-		63AFBAAD20D0FC54009E3D1C /* LineEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAAA20D0FC54009E3D1C /* LineEvent.swift */; };
-		63AFBAAE20D0FC54009E3D1C /* LineEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAAA20D0FC54009E3D1C /* LineEvent.swift */; };
+		63AFBAA120D0FC21009E3D1C /* TicketWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA020D0FC21009E3D1C /* TicketWebsocketEvent.swift */; };
+		63AFBAA220D0FC21009E3D1C /* TicketWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA020D0FC21009E3D1C /* TicketWebsocketEvent.swift */; };
+		63AFBAA320D0FC21009E3D1C /* TicketWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA020D0FC21009E3D1C /* TicketWebsocketEvent.swift */; };
+		63AFBAA420D0FC21009E3D1C /* TicketWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA020D0FC21009E3D1C /* TicketWebsocketEvent.swift */; };
+		63AFBAA620D0FC42009E3D1C /* DeviceWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA520D0FC42009E3D1C /* DeviceWebsocketEvent.swift */; };
+		63AFBAA720D0FC42009E3D1C /* DeviceWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA520D0FC42009E3D1C /* DeviceWebsocketEvent.swift */; };
+		63AFBAA820D0FC42009E3D1C /* DeviceWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA520D0FC42009E3D1C /* DeviceWebsocketEvent.swift */; };
+		63AFBAA920D0FC42009E3D1C /* DeviceWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAA520D0FC42009E3D1C /* DeviceWebsocketEvent.swift */; };
+		63AFBAAB20D0FC54009E3D1C /* LineWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAAA20D0FC54009E3D1C /* LineWebsocketEvent.swift */; };
+		63AFBAAC20D0FC54009E3D1C /* LineWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAAA20D0FC54009E3D1C /* LineWebsocketEvent.swift */; };
+		63AFBAAD20D0FC54009E3D1C /* LineWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAAA20D0FC54009E3D1C /* LineWebsocketEvent.swift */; };
+		63AFBAAE20D0FC54009E3D1C /* LineWebsocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFBAAA20D0FC54009E3D1C /* LineWebsocketEvent.swift */; };
 		63B913EE2050124D0096F92D /* QminderAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B913ED2050124D0096F92D /* QminderAPIProtocol.swift */; };
 		63B913EF2050124D0096F92D /* QminderAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B913ED2050124D0096F92D /* QminderAPIProtocol.swift */; };
 		63B913F02050124D0096F92D /* QminderAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B913ED2050124D0096F92D /* QminderAPIProtocol.swift */; };
@@ -297,7 +297,7 @@
 		63520649204D78E5008C8C54 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		6352064A204D78E5008C8C54 /* HTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		6352064C204D78E5008C8C54 /* QminderEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QminderEvents.swift; sourceTree = "<group>"; };
-		6352064D204D78E5008C8C54 /* QminderEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QminderEvent.swift; sourceTree = "<group>"; };
+		6352064D204D78E5008C8C54 /* QminderWebsocketEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QminderWebsocketEvent.swift; sourceTree = "<group>"; };
 		6352064F204D78E5008C8C54 /* EventResponsable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventResponsable.swift; sourceTree = "<group>"; };
 		63520650204D78E5008C8C54 /* LinesEventResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinesEventResponse.swift; sourceTree = "<group>"; };
 		63520651204D78E5008C8C54 /* DeviceEventResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceEventResponse.swift; sourceTree = "<group>"; };
@@ -322,9 +322,9 @@
 		639E578D20AD8DF50089C90B /* TestHelperExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelperExtensions.swift; sourceTree = "<group>"; };
 		63AFBA9620D009E8009E3D1C /* WebsocketMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebsocketMessage.swift; sourceTree = "<group>"; };
 		63AFBA9B20D00A0D009E3D1C /* Callback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Callback.swift; sourceTree = "<group>"; };
-		63AFBAA020D0FC21009E3D1C /* TicketEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketEvent.swift; sourceTree = "<group>"; };
-		63AFBAA520D0FC42009E3D1C /* DeviceEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceEvent.swift; sourceTree = "<group>"; };
-		63AFBAAA20D0FC54009E3D1C /* LineEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEvent.swift; sourceTree = "<group>"; };
+		63AFBAA020D0FC21009E3D1C /* TicketWebsocketEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketWebsocketEvent.swift; sourceTree = "<group>"; };
+		63AFBAA520D0FC42009E3D1C /* DeviceWebsocketEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceWebsocketEvent.swift; sourceTree = "<group>"; };
+		63AFBAAA20D0FC54009E3D1C /* LineWebsocketEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineWebsocketEvent.swift; sourceTree = "<group>"; };
 		63B913ED2050124D0096F92D /* QminderAPIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QminderAPIProtocol.swift; sourceTree = "<group>"; };
 		63C422E3205678D600941DA4 /* QminderErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QminderErrorTests.swift; sourceTree = "<group>"; };
 		63C422E520567F3000941DA4 /* ResponseDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseDataTests.swift; sourceTree = "<group>"; };
@@ -504,10 +504,10 @@
 				6352064C204D78E5008C8C54 /* QminderEvents.swift */,
 				63AFBA9620D009E8009E3D1C /* WebsocketMessage.swift */,
 				63AFBA9B20D00A0D009E3D1C /* Callback.swift */,
-				6352064D204D78E5008C8C54 /* QminderEvent.swift */,
-				63AFBAA020D0FC21009E3D1C /* TicketEvent.swift */,
-				63AFBAA520D0FC42009E3D1C /* DeviceEvent.swift */,
-				63AFBAAA20D0FC54009E3D1C /* LineEvent.swift */,
+				6352064D204D78E5008C8C54 /* QminderWebsocketEvent.swift */,
+				63AFBAA020D0FC21009E3D1C /* TicketWebsocketEvent.swift */,
+				63AFBAA520D0FC42009E3D1C /* DeviceWebsocketEvent.swift */,
+				63AFBAAA20D0FC54009E3D1C /* LineWebsocketEvent.swift */,
 				6352064E204D78E5008C8C54 /* Models */,
 				63520653204D78E5008C8C54 /* QminderEventsDelegate.swift */,
 			);
@@ -983,7 +983,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6320D84B204D81440041FFAC /* QminderEvent.swift in Sources */,
+				6320D84B204D81440041FFAC /* QminderWebsocketEvent.swift in Sources */,
 				6320D85F204D81550041FFAC /* Status.swift in Sources */,
 				6304932C2052AFBB001529B4 /* Responsable.swift in Sources */,
 				631849702051703C0082068A /* QminderAPIEndpoint.swift in Sources */,
@@ -992,7 +992,7 @@
 				6318496B20516EC40082068A /* QminderAPIEndpointProtocol.swift in Sources */,
 				6320D854204D81510041FFAC /* EmptyState.swift in Sources */,
 				6315470220A47B9A0032B2EC /* QminderEventsProtocol.swift in Sources */,
-				63AFBAAB20D0FC54009E3D1C /* LineEvent.swift in Sources */,
+				63AFBAAB20D0FC54009E3D1C /* LineWebsocketEvent.swift in Sources */,
 				6320D85E204D81550041FFAC /* Extra.swift in Sources */,
 				6320D858204D81510041FFAC /* Desk.swift in Sources */,
 				63AFBA9720D009E8009E3D1C /* WebsocketMessage.swift in Sources */,
@@ -1013,7 +1013,7 @@
 				6320D863204D81580041FFAC /* ParameterEncoding.swift in Sources */,
 				6320D864204D815B0041FFAC /* ResultProtocol.swift in Sources */,
 				6320D84E204D81480041FFAC /* DeviceEventResponse.swift in Sources */,
-				63AFBAA120D0FC21009E3D1C /* TicketEvent.swift in Sources */,
+				63AFBAA120D0FC21009E3D1C /* TicketWebsocketEvent.swift in Sources */,
 				6320D861204D81550041FFAC /* Created.swift in Sources */,
 				63AFBA9C20D00A0D009E3D1C /* Callback.swift in Sources */,
 				6320D865204D815B0041FFAC /* Result.swift in Sources */,
@@ -1024,7 +1024,7 @@
 				6320D85D204D81550041FFAC /* Ticket.swift in Sources */,
 				6320D84C204D81480041FFAC /* EventResponsable.swift in Sources */,
 				637D698F2052EA0500C59BA2 /* Extensions+Data.swift in Sources */,
-				63AFBAA620D0FC42009E3D1C /* DeviceEvent.swift in Sources */,
+				63AFBAA620D0FC42009E3D1C /* DeviceWebsocketEvent.swift in Sources */,
 				6320D853204D81510041FFAC /* TVAPIData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1078,7 +1078,7 @@
 				6318496C20516EC40082068A /* QminderAPIEndpointProtocol.swift in Sources */,
 				635206AD204D7A2A008C8C54 /* Result.swift in Sources */,
 				6315470320A47B9A0032B2EC /* QminderEventsProtocol.swift in Sources */,
-				63AFBAAC20D0FC54009E3D1C /* LineEvent.swift in Sources */,
+				63AFBAAC20D0FC54009E3D1C /* LineWebsocketEvent.swift in Sources */,
 				635206B8204D7A34008C8C54 /* Location.swift in Sources */,
 				635206D0204D7A39008C8C54 /* Status.swift in Sources */,
 				63AFBA9820D009E8009E3D1C /* WebsocketMessage.swift in Sources */,
@@ -1089,7 +1089,7 @@
 				635206D2204D7A39008C8C54 /* Created.swift in Sources */,
 				635206CE204D7A39008C8C54 /* Ticket.swift in Sources */,
 				635206B3204D7A2E008C8C54 /* ParameterEncoding.swift in Sources */,
-				635206F5204D7A43008C8C54 /* QminderEvent.swift in Sources */,
+				635206F5204D7A43008C8C54 /* QminderWebsocketEvent.swift in Sources */,
 				63B913EF2050124D0096F92D /* QminderAPIProtocol.swift in Sources */,
 				635206CD204D7A39008C8C54 /* Interaction.swift in Sources */,
 				635206CF204D7A39008C8C54 /* Extra.swift in Sources */,
@@ -1099,7 +1099,7 @@
 				635206F1204D7A3F008C8C54 /* QminderAPI.swift in Sources */,
 				635206FF204D7A4B008C8C54 /* DeviceEventResponse.swift in Sources */,
 				635206AC204D7A2A008C8C54 /* ResultProtocol.swift in Sources */,
-				63AFBAA220D0FC21009E3D1C /* TicketEvent.swift in Sources */,
+				63AFBAA220D0FC21009E3D1C /* TicketWebsocketEvent.swift in Sources */,
 				635206CC204D7A39008C8C54 /* TicketResponse.swift in Sources */,
 				63AFBA9D20D00A0D009E3D1C /* Callback.swift in Sources */,
 				635206FD204D7A4B008C8C54 /* EventResponsable.swift in Sources */,
@@ -1110,7 +1110,7 @@
 				635206BD204D7A34008C8C54 /* Line.swift in Sources */,
 				635206FA204D7A46008C8C54 /* QminderEventsDelegate.swift in Sources */,
 				637D69902052EA0500C59BA2 /* Extensions+Data.swift in Sources */,
-				63AFBAA720D0FC42009E3D1C /* DeviceEvent.swift in Sources */,
+				63AFBAA720D0FC42009E3D1C /* DeviceWebsocketEvent.swift in Sources */,
 				635206EF204D7A3F008C8C54 /* Device.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1128,7 +1128,7 @@
 				6318496D20516EC40082068A /* QminderAPIEndpointProtocol.swift in Sources */,
 				635206AF204D7A2B008C8C54 /* Result.swift in Sources */,
 				6315470420A47B9A0032B2EC /* QminderEventsProtocol.swift in Sources */,
-				63AFBAAD20D0FC54009E3D1C /* LineEvent.swift in Sources */,
+				63AFBAAD20D0FC54009E3D1C /* LineWebsocketEvent.swift in Sources */,
 				635206BE204D7A35008C8C54 /* Location.swift in Sources */,
 				635206D9204D7A39008C8C54 /* Status.swift in Sources */,
 				63AFBA9920D009E8009E3D1C /* WebsocketMessage.swift in Sources */,
@@ -1139,7 +1139,7 @@
 				635206DB204D7A39008C8C54 /* Created.swift in Sources */,
 				635206D7204D7A39008C8C54 /* Ticket.swift in Sources */,
 				635206B5204D7A2E008C8C54 /* ParameterEncoding.swift in Sources */,
-				635206F7204D7A43008C8C54 /* QminderEvent.swift in Sources */,
+				635206F7204D7A43008C8C54 /* QminderWebsocketEvent.swift in Sources */,
 				63B913F02050124D0096F92D /* QminderAPIProtocol.swift in Sources */,
 				635206D6204D7A39008C8C54 /* Interaction.swift in Sources */,
 				635206D8204D7A39008C8C54 /* Extra.swift in Sources */,
@@ -1149,7 +1149,7 @@
 				635206EC204D7A3E008C8C54 /* QminderAPI.swift in Sources */,
 				63520703204D7A4B008C8C54 /* DeviceEventResponse.swift in Sources */,
 				635206AE204D7A2B008C8C54 /* ResultProtocol.swift in Sources */,
-				63AFBAA320D0FC21009E3D1C /* TicketEvent.swift in Sources */,
+				63AFBAA320D0FC21009E3D1C /* TicketWebsocketEvent.swift in Sources */,
 				635206D5204D7A39008C8C54 /* TicketResponse.swift in Sources */,
 				63AFBA9E20D00A0D009E3D1C /* Callback.swift in Sources */,
 				63520701204D7A4B008C8C54 /* EventResponsable.swift in Sources */,
@@ -1160,7 +1160,7 @@
 				635206C3204D7A35008C8C54 /* Line.swift in Sources */,
 				635206FB204D7A46008C8C54 /* QminderEventsDelegate.swift in Sources */,
 				637D69912052EA0500C59BA2 /* Extensions+Data.swift in Sources */,
-				63AFBAA820D0FC42009E3D1C /* DeviceEvent.swift in Sources */,
+				63AFBAA820D0FC42009E3D1C /* DeviceWebsocketEvent.swift in Sources */,
 				635206EA204D7A3E008C8C54 /* Device.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1178,7 +1178,7 @@
 				6318496E20516EC40082068A /* QminderAPIEndpointProtocol.swift in Sources */,
 				635206B1204D7A2B008C8C54 /* Result.swift in Sources */,
 				6315470520A47B9A0032B2EC /* QminderEventsProtocol.swift in Sources */,
-				63AFBAAE20D0FC54009E3D1C /* LineEvent.swift in Sources */,
+				63AFBAAE20D0FC54009E3D1C /* LineWebsocketEvent.swift in Sources */,
 				635206C4204D7A35008C8C54 /* Location.swift in Sources */,
 				635206E2204D7A3A008C8C54 /* Status.swift in Sources */,
 				63AFBA9A20D009E8009E3D1C /* WebsocketMessage.swift in Sources */,
@@ -1189,7 +1189,7 @@
 				635206E4204D7A3A008C8C54 /* Created.swift in Sources */,
 				635206E0204D7A3A008C8C54 /* Ticket.swift in Sources */,
 				635206B7204D7A2F008C8C54 /* ParameterEncoding.swift in Sources */,
-				635206F9204D7A43008C8C54 /* QminderEvent.swift in Sources */,
+				635206F9204D7A43008C8C54 /* QminderWebsocketEvent.swift in Sources */,
 				63B913F12050124D0096F92D /* QminderAPIProtocol.swift in Sources */,
 				635206DF204D7A3A008C8C54 /* Interaction.swift in Sources */,
 				635206E1204D7A3A008C8C54 /* Extra.swift in Sources */,
@@ -1199,7 +1199,7 @@
 				635206E7204D7A3E008C8C54 /* QminderAPI.swift in Sources */,
 				63520707204D7A4B008C8C54 /* DeviceEventResponse.swift in Sources */,
 				635206B0204D7A2B008C8C54 /* ResultProtocol.swift in Sources */,
-				63AFBAA420D0FC21009E3D1C /* TicketEvent.swift in Sources */,
+				63AFBAA420D0FC21009E3D1C /* TicketWebsocketEvent.swift in Sources */,
 				635206DE204D7A3A008C8C54 /* TicketResponse.swift in Sources */,
 				63AFBA9F20D00A0D009E3D1C /* Callback.swift in Sources */,
 				63520705204D7A4B008C8C54 /* EventResponsable.swift in Sources */,
@@ -1210,7 +1210,7 @@
 				635206C9204D7A35008C8C54 /* Line.swift in Sources */,
 				635206FC204D7A47008C8C54 /* QminderEventsDelegate.swift in Sources */,
 				637D69922052EA0500C59BA2 /* Extensions+Data.swift in Sources */,
-				63AFBAA920D0FC42009E3D1C /* DeviceEvent.swift in Sources */,
+				63AFBAA920D0FC42009E3D1C /* DeviceWebsocketEvent.swift in Sources */,
 				635206E5204D7A3E008C8C54 /* Device.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/QminderAPIPlayground.playground/Contents.swift
+++ b/QminderAPIPlayground.playground/Contents.swift
@@ -75,3 +75,29 @@ qminderAPI.tvHeartbeat(id: 11389, metadata: ["test": "test"]) {
   print("TV heartbeat")
   print($0)
 }
+
+extension TicketEvent: CustomStringConvertible {
+  public var description: String {
+    switch self {
+      
+    case .created:
+      return "creat"
+    case .called:
+      return "c"
+    case .recalled:
+      return "c"
+    case .cancelled:
+      return "c"
+    case .served:
+      return "c"
+    case .changed:
+      return "c"
+    }
+  }
+  
+  
+}
+
+let te = TicketEvent.created
+
+print(te)

--- a/QminderAPIPlayground.playground/Contents.swift
+++ b/QminderAPIPlayground.playground/Contents.swift
@@ -75,29 +75,3 @@ qminderAPI.tvHeartbeat(id: 11389, metadata: ["test": "test"]) {
   print("TV heartbeat")
   print($0)
 }
-
-extension TicketEvent: CustomStringConvertible {
-  public var description: String {
-    switch self {
-      
-    case .created:
-      return "creat"
-    case .called:
-      return "c"
-    case .recalled:
-      return "c"
-    case .cancelled:
-      return "c"
-    case .served:
-      return "c"
-    case .changed:
-      return "c"
-    }
-  }
-  
-  
-}
-
-let te = TicketEvent.created
-
-print(te)

--- a/QminderAPITests/EventTests/QminderWebsocketTests.swift
+++ b/QminderAPITests/EventTests/QminderWebsocketTests.swift
@@ -176,7 +176,7 @@ class QminderWebsocketTests: XCTestCase {
     }
   }
   
-  fileprivate func subscribeToTicket(_ ticketEvent: TicketEvent, parameters: [String: Any]) {
+  fileprivate func subscribeToTicket(_ ticketEvent: TicketWebsocketEvent, parameters: [String: Any]) {
     events.subscribe(toTicketEvent: ticketEvent, parameters: parameters, callback: { result in
       
       XCTAssertTrue(Thread.isMainThread)

--- a/QminderAPITests/QminderEventsTests.swift
+++ b/QminderAPITests/QminderEventsTests.swift
@@ -27,7 +27,7 @@ class QminderEventsMock: QminderEventsProtocol {
     delegate?.onDisconnected(error: error)
   }
   
-  func subscribe(toTicketEvent eventType: TicketEvent,
+  func subscribe(toTicketEvent eventType: TicketWebsocketEvent,
                  parameters: [String: Any], callback: @escaping (Result<Ticket, QminderError>) -> Void) {
     let ticket = Ticket(statusCode: 200,
                         id: "1",
@@ -47,7 +47,7 @@ class QminderEventsMock: QminderEventsProtocol {
     callback(Result.init(ticket))
   }
   
-  func subscribe(toDeviceEvent eventType: DeviceEvent,
+  func subscribe(toDeviceEvent eventType: DeviceWebsocketEvent,
                  parameters: [String: Any], callback: @escaping (Result<TVDevice?, QminderError>) -> Void) {
     
     let settings = Settings.init(selectedLine: 1, lines: [1, 2, 3], clearTickets: .afterCalling)
@@ -61,7 +61,7 @@ class QminderEventsMock: QminderEventsProtocol {
     callback(Result.init(tvDevice))
   }
   
-  func subscribe(toLineEvent eventType: LineEvent,
+  func subscribe(toLineEvent eventType: LineWebsocketEvent,
                  parameters: [String: Any], callback: @escaping (Result<[Line], QminderError>) -> Void) {
     
     let lines = [Line(statusCode: 200, id: 1, name: "Line1", location: 1),

--- a/Sources/Events/Callback.swift
+++ b/Sources/Events/Callback.swift
@@ -12,11 +12,11 @@ import Foundation
 internal enum Callback {
   
   /// Ticket callback
-  case ticket(EventsCallbackType<Ticket>)
+  case ticket((Result<Ticket, QminderError>) -> Void)
   
   /// Device callback
-  case device(EventsCallbackType<TVDevice?>)
+  case device((Result<TVDevice?, QminderError>) -> Void)
   
   /// Line callback
-  case line(EventsCallbackType<[Line]>)
+  case line((Result<[Line], QminderError>) -> Void)
 }

--- a/Sources/Events/DeviceWebsocketEvent.swift
+++ b/Sources/Events/DeviceWebsocketEvent.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Device events
-public enum DeviceEvent: String {
+public enum DeviceWebsocketEvent: String {
   
   /// Overview monitor changed
   case overviewMonitorChange = "OVERVIEW_MONITOR_CHANGE"

--- a/Sources/Events/LineWebsocketEvent.swift
+++ b/Sources/Events/LineWebsocketEvent.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Line events
-public enum LineEvent: String {
+public enum LineWebsocketEvent: String {
   
   /// Lines changed
   case changed = "LINES_CHANGED"

--- a/Sources/Events/QminderEvents.swift
+++ b/Sources/Events/QminderEvents.swift
@@ -94,7 +94,7 @@ public class QminderEvents: QminderEventsProtocol {
     self.socket.disconnect(closeCode: Constants.websocketReservedCloseCode)
   }
 
-  public func subscribe(toTicketEvent eventType: TicketEvent,
+  public func subscribe(toTicketEvent eventType: TicketWebsocketEvent,
                         parameters: [String: Any], callback: @escaping EventsCallbackType<Ticket>) {
     
     guard let (message, subscriptionId) = parseParameters(eventType: .ticket(eventType), parameters: parameters) else {
@@ -108,7 +108,7 @@ public class QminderEvents: QminderEventsProtocol {
                            callback: .ticket(callback))
   }
 
-  public func subscribe(toDeviceEvent eventType: DeviceEvent,
+  public func subscribe(toDeviceEvent eventType: DeviceWebsocketEvent,
                         parameters: [String: Any], callback: @escaping EventsCallbackType<TVDevice?>) {
     
     guard let (message, subscriptionId) = parseParameters(eventType: .device(eventType), parameters: parameters) else {
@@ -122,7 +122,7 @@ public class QminderEvents: QminderEventsProtocol {
                            callback: .device(callback))
   }
   
-  public func subscribe(toLineEvent eventType: LineEvent,
+  public func subscribe(toLineEvent eventType: LineWebsocketEvent,
                         parameters: [String: Any], callback: @escaping EventsCallbackType<[Line]>) {
     
     guard let (message, subscriptionId) = parseParameters(eventType: .line(eventType), parameters: parameters) else {
@@ -144,7 +144,7 @@ public class QminderEvents: QminderEventsProtocol {
   ///   - message: Message to send
   ///   - callback: Callback execute when websocket event has accoured
   private func sendMessageToWebsocket(subscriptionId: String,
-                                      eventType: QminderEvent,
+                                      eventType: QminderWebsocketEvent,
                                       message: String,
                                       callback: Callback) {
     if socket.isConnected {
@@ -168,7 +168,7 @@ public class QminderEvents: QminderEventsProtocol {
   /// - Parameters:
   ///   - eventType: Qminder event type
   ///   - parameters: Parameters
-  private func parseParameters(eventType: QminderEvent,
+  private func parseParameters(eventType: QminderWebsocketEvent,
                                parameters: [String: Any]) -> (message: String, subscriptionId: String)? {
     
     var parameters = parameters
@@ -208,7 +208,10 @@ public class QminderEvents: QminderEventsProtocol {
   ///   - eventType: Qminder event type
   ///   - messageToSend: Message to send to Websocket
   ///   - callback: Callback block when response is received
-  private func sendMessage(subscriptionId: String, eventType: QminderEvent, messageToSend: String, callback: Callback) {
+  private func sendMessage(subscriptionId: String,
+                           eventType: QminderWebsocketEvent,
+                           messageToSend: String,
+                           callback: Callback) {
     self.callbackMap[subscriptionId] = callback
     self.socket.write(string: messageToSend)
   }

--- a/Sources/Events/QminderEvents.swift
+++ b/Sources/Events/QminderEvents.swift
@@ -95,7 +95,8 @@ public class QminderEvents: QminderEventsProtocol {
   }
 
   public func subscribe(toTicketEvent eventType: TicketWebsocketEvent,
-                        parameters: [String: Any], callback: @escaping EventsCallbackType<Ticket>) {
+                        parameters: [String: Any],
+                        callback: @escaping (Result<Ticket, QminderError>) -> Void) {
     
     guard let (message, subscriptionId) = parseParameters(eventType: .ticket(eventType), parameters: parameters) else {
       callback(Result.failure(QminderError.parse))
@@ -109,7 +110,8 @@ public class QminderEvents: QminderEventsProtocol {
   }
 
   public func subscribe(toDeviceEvent eventType: DeviceWebsocketEvent,
-                        parameters: [String: Any], callback: @escaping EventsCallbackType<TVDevice?>) {
+                        parameters: [String: Any],
+                        callback: @escaping (Result<TVDevice?, QminderError>) -> Void) {
     
     guard let (message, subscriptionId) = parseParameters(eventType: .device(eventType), parameters: parameters) else {
       callback(Result.failure(QminderError.parse))
@@ -123,7 +125,8 @@ public class QminderEvents: QminderEventsProtocol {
   }
   
   public func subscribe(toLineEvent eventType: LineWebsocketEvent,
-                        parameters: [String: Any], callback: @escaping EventsCallbackType<[Line]>) {
+                        parameters: [String: Any],
+                        callback: @escaping (Result<[Line], QminderError>) -> Void) {
     
     guard let (message, subscriptionId) = parseParameters(eventType: .line(eventType), parameters: parameters) else {
       callback(Result.failure(QminderError.parse))
@@ -175,7 +178,7 @@ public class QminderEvents: QminderEventsProtocol {
     let subscriptionId = String(withRandomLenght: 30)
     
     parameters["id"] = subscriptionId
-    parameters["subscribe"] = eventType.value
+    parameters["subscribe"] = eventType.description
     
     do {
       let jsonData = try JSONSerialization.data(withJSONObject: parameters, options: [])

--- a/Sources/Events/QminderEventsDelegate.swift
+++ b/Sources/Events/QminderEventsDelegate.swift
@@ -10,16 +10,12 @@ import Foundation
 /// QminderEvents delagate methods
 public protocol QminderEventsDelegate: class {
   
-  /**
-   Called when connected to Websocket
-   */
+  /// Called when connected to Websocket
   func onConnected()
   
-  /**
-   Called when disconnected from Websocket
-   
-   - Parameter error: Error why it got disconnected
-   */
+  /// Called when disconnected from Websocket
+  ///
+  /// - Parameter error: Error why it got disconnected
   func onDisconnected(error: Error?)
   
 }

--- a/Sources/Events/QminderEventsProtocol.swift
+++ b/Sources/Events/QminderEventsProtocol.swift
@@ -8,9 +8,6 @@
 
 import Foundation
 
-/// Callback type when subscrubing to evenets
-public typealias EventsCallbackType<T> = (Result<T, QminderError>) -> Void
-
 /// Qminder Events protocol
 public protocol QminderEventsProtocol {
   
@@ -34,7 +31,7 @@ public protocol QminderEventsProtocol {
   ///   - callback: Callback executed when response got from Websocket
   func subscribe(toTicketEvent eventType: TicketWebsocketEvent,
                  parameters: [String: Any],
-                 callback: @escaping EventsCallbackType<Ticket>)
+                 callback: @escaping (Result<Ticket, QminderError>) -> Void)
   
   /// Subscribe to device event
   ///
@@ -44,7 +41,7 @@ public protocol QminderEventsProtocol {
   ///   - callback: Callback executed when response got from Websocket
   func subscribe(toDeviceEvent eventType: DeviceWebsocketEvent,
                  parameters: [String: Any],
-                 callback: @escaping EventsCallbackType<TVDevice?>)
+                 callback: @escaping (Result<TVDevice?, QminderError>) -> Void)
   
   /// Subscribe to lines event
   ///
@@ -54,5 +51,5 @@ public protocol QminderEventsProtocol {
   ///   - callback: Callback executed when response got from Websocket
   func subscribe(toLineEvent eventType: LineWebsocketEvent,
                  parameters: [String: Any],
-                 callback: @escaping EventsCallbackType<[Line]>)
+                 callback: @escaping (Result<[Line], QminderError>) -> Void)
 }

--- a/Sources/Events/QminderEventsProtocol.swift
+++ b/Sources/Events/QminderEventsProtocol.swift
@@ -32,7 +32,7 @@ public protocol QminderEventsProtocol {
   ///   - eventType: Event type to subscribe
   ///   - parameters: Dictionary of parameters
   ///   - callback: Callback executed when response got from Websocket
-  func subscribe(toTicketEvent eventType: TicketEvent,
+  func subscribe(toTicketEvent eventType: TicketWebsocketEvent,
                  parameters: [String: Any],
                  callback: @escaping EventsCallbackType<Ticket>)
   
@@ -42,7 +42,7 @@ public protocol QminderEventsProtocol {
   ///   - eventType: Event type to subscribe
   ///   - parameters: Dictionary of parameters
   ///   - callback: Callback executed when response got from Websocket
-  func subscribe(toDeviceEvent eventType: DeviceEvent,
+  func subscribe(toDeviceEvent eventType: DeviceWebsocketEvent,
                  parameters: [String: Any],
                  callback: @escaping EventsCallbackType<TVDevice?>)
   
@@ -52,7 +52,7 @@ public protocol QminderEventsProtocol {
   ///   - eventType: Event type to subscribe
   ///   - parameters: Dictionary of parameters
   ///   - callback: Callback executed when response got from Websocket
-  func subscribe(toLineEvent eventType: LineEvent,
+  func subscribe(toLineEvent eventType: LineWebsocketEvent,
                  parameters: [String: Any],
                  callback: @escaping EventsCallbackType<[Line]>)
 }

--- a/Sources/Events/QminderWebsocketEvent.swift
+++ b/Sources/Events/QminderWebsocketEvent.swift
@@ -18,9 +18,10 @@ public enum QminderWebsocketEvent {
   
   /// Line events
   case line(LineWebsocketEvent)
-  
-  /// String value for event
-  var value: String {
+}
+
+extension QminderWebsocketEvent: CustomStringConvertible {
+  public var description: String {
     switch self {
     case .ticket(let ticketEvent):
       return ticketEvent.rawValue

--- a/Sources/Events/QminderWebsocketEvent.swift
+++ b/Sources/Events/QminderWebsocketEvent.swift
@@ -7,17 +7,17 @@
 
 import Foundation
 
-/// Qminder Event type
-public enum QminderEvent {
+/// Qminder Websocket Event type
+public enum QminderWebsocketEvent {
   
   /// Ticket events
-  case ticket(TicketEvent)
+  case ticket(TicketWebsocketEvent)
   
   /// Device events
-  case device(DeviceEvent)
+  case device(DeviceWebsocketEvent)
   
   /// Line events
-  case line(LineEvent)
+  case line(LineWebsocketEvent)
   
   /// String value for event
   var value: String {

--- a/Sources/Events/TicketWebsocketEvent.swift
+++ b/Sources/Events/TicketWebsocketEvent.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Ticket events
-public enum TicketEvent: String {
+public enum TicketWebsocketEvent: String {
   
   /// Ticket created
   case created = "TICKET_CREATED"

--- a/Sources/Events/WebsocketMessage.swift
+++ b/Sources/Events/WebsocketMessage.swift
@@ -15,7 +15,7 @@ internal struct WebsocketMessage {
   var subscriptionId: String
   
   /// Qminder event
-  var eventType: QminderEvent
+  var eventType: QminderWebsocketEvent
   
   /// String message what should be sent to Websocket
   var messageToSend: String


### PR DESCRIPTION
* renamed event structs so it won’t clash with QminderTV project and would be more descriptive
* removed typealias EventsCallbackType
* let’s use Swift CustomStringConvertible for QminderWebsocketEvent instead of just variable, so it will be nicely printed
* improved some comments