### PR TITLE
feat(api): use tv-pairing-code service

### DIFF
--- a/Sources/QminderAPI.swift
+++ b/Sources/QminderAPI.swift
@@ -17,7 +17,7 @@ public struct QminderAPI: QminderAPIProtocolResponse {
   /// Qminder API address
   private var serverAddress: String
 
-  /// Qminder TV Pairig Code address
+  /// Qminder TV Pairing Code address
   private var tvPairingServerAddress: String
   
   /// Queue to return result in

--- a/Sources/QminderAPI.swift
+++ b/Sources/QminderAPI.swift
@@ -10,324 +10,322 @@ import Foundation
 
 /// Qminder API
 public struct QminderAPI: QminderAPIProtocolResponse {
-    
-    /// Qminder API key
-    private var apiKey: String?
-    
-    /// Qminder API address
-    private var serverAddress: String
-    
-    /// Qminder TV Pairig Code address
-    private var tvPairingServerAddress: String
-    
-    /// Queue to return result in
-    private var queue = DispatchQueue.main
-    
-    public init(apiKey: String? = nil,
-                serverAddress: String = "https://api.qminder.com/v1",
-                tvPairingServerAddress: String = "https://tv.qminder.com") {
-        self.apiKey = apiKey
-        self.serverAddress = serverAddress
-        self.tvPairingServerAddress = tvPairingServerAddress
-    }
-    
-    public func getLocationsList(completion: @escaping (Result<[Location], QminderError>) -> Void) {
-        getLocationsList { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func getLocationsList(completion: @escaping (Result<[Location], QminderError>, HTTPURLResponse?) -> Void) {
-        fetch(.locations, decodingType: Locations.self) { result, response in
-            completion(result, response)
-        }
-    }
-    
-    public func getLocationLines(locationId: Int, completion: @escaping (Result<[Line], QminderError>) -> Void) {
-        getLocationLines(locationId: locationId) { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func getLocationLines(locationId: Int,
-                                 completion: @escaping (Result<[Line], QminderError>, HTTPURLResponse?) -> Void) {
-        fetch(.lines(locationId), decodingType: Lines.self) { result, response in
-            completion(result, response)
-        }
-    }
-    
-    public func getLineDetails(lineId: Int, completion: @escaping (Result<Line, QminderError>) -> Void) {
-        getLineDetails(lineId: lineId) { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func getLineDetails(lineId: Int,
-                               completion: @escaping (Result<Line, QminderError>, HTTPURLResponse?) -> Void) {
-        fetch(.line(lineId), decodingType: Line.self) { result, response in
-            completion(result, response)
-        }
-    }
-    
-    public func getTicketDetails(ticketId: String, completion: @escaping (Result<Ticket, QminderError>) -> Void) {
-        getTicketDetails(ticketId: ticketId) { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func getTicketDetails(ticketId: String,
-                                 completion: @escaping (Result<Ticket, QminderError>, HTTPURLResponse?) -> Void) {
-        fetch(.ticket(ticketId), decodingType: Ticket.self) { result, response in
-            completion(result, response)
-        }
-    }
-    
-    public func getUserDetails(userId: Int, completion: @escaping (Result<User, QminderError>) -> Void) {
-        getUserDetails(userId: userId) { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func getUserDetails(userId: Int,
-                               completion: @escaping (Result<User, QminderError>, HTTPURLResponse?) -> Void) {
-        fetch(.user(userId), decodingType: User.self) { result, response in
-            completion(result, response)
-        }
-    }
-    
-    public func getPairingCodeAndSecret(completion: @escaping (Result<TVPairingCode, QminderError>) -> Void) {
-        getPairingCodeAndSecret { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func getPairingCodeAndSecret(
-        completion: @escaping (Result<TVPairingCode, QminderError>, HTTPURLResponse?) -> Void) {
-            fetchTvPairing(.tvCode, decodingType: TVPairingCode.self) { result, response in
-                completion(result, response)
-            }
-        }
-    
-    public func pairTV(code: String,
-                       secret: String,
-                       completion: @escaping (Result<TVAPIData, QminderError>) -> Void) {
-        pairTV(code: code, secret: secret) { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func pairTV(code: String,
-                       secret: String,
-                       completion: @escaping (Result<TVAPIData, QminderError>, HTTPURLResponse?) -> Void) {
-        fetchTvPairing(.tvPairingStatus(code, ["secret": secret]), decodingType: TVAPIData.self) { result, response in
-            completion(result, response)
-        }
-    }
-    
-    public func tvDetails(id: Int, completion: @escaping (Result<TVDevice, QminderError>) -> Void) {
-        tvDetails(id: id) { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func tvDetails(id: Int, completion: @escaping (Result<TVDevice, QminderError>, HTTPURLResponse?) -> Void) {
-        fetch(.tvDetails(id), decodingType: TVDevice.self) { result, response in
-            completion(result, response)
-        }
-    }
-    
-    public func tvHeartbeat(id: Int, metadata: [String: Any],
-                            completion: @escaping (Result<Void?, QminderError>) -> Void) {
-        tvHeartbeat(id: id, metadata: metadata) { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func tvHeartbeat(id: Int, metadata: [String: Any],
-                            completion: @escaping (Result<Void?, QminderError>, HTTPURLResponse?) -> Void) {
-        fetch(.tvHeartbeat(id, metadata)) { result, response in
-            completion(result, response)
-        }
-    }
-    
-    public func tvEmptyState(id: Int, language: String,
-                             completion: @escaping (Result<EmptyState, QminderError>) -> Void) {
-        tvEmptyState(id: id, language: language) { result, _ in
-            completion(result)
-        }
-    }
-    
-    public func tvEmptyState(id: Int, language: String,
-                             completion: @escaping (Result<EmptyState, QminderError>, HTTPURLResponse?) -> Void) {
-        fetch(.tvEmptyState(id, ["language": language]), decodingType: EmptyState.self) { result, response in
-            completion(result, response)
-        }
-    }
-}
+  
+  /// Qminder API key
+  private var apiKey: String?
+  
+  /// Qminder API address
+  private var serverAddress: String
 
+  /// Qminder TV Pairig Code address
+  private var tvPairingServerAddress: String
+  
+  /// Queue to return result in
+  private var queue = DispatchQueue.main
+  
+  public init(apiKey: String? = nil,
+              serverAddress: String = "https://api.qminder.com/v1",
+              tvPairingServerAddress: String = "https://tv.qminder.com") {
+    self.apiKey = apiKey
+    self.serverAddress = serverAddress
+    self.tvPairingServerAddress = tvPairingServerAddress
+  }
+  
+  public func getLocationsList(completion: @escaping (Result<[Location], QminderError>) -> Void) {
+    getLocationsList { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func getLocationsList(completion: @escaping (Result<[Location], QminderError>, HTTPURLResponse?) -> Void) {
+    fetch(.locations, decodingType: Locations.self) { result, response in
+      completion(result, response)
+    }
+  }
+    
+  public func getLocationLines(locationId: Int, completion: @escaping (Result<[Line], QminderError>) -> Void) {
+    getLocationLines(locationId: locationId) { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func getLocationLines(locationId: Int,
+                               completion: @escaping (Result<[Line], QminderError>, HTTPURLResponse?) -> Void) {
+    fetch(.lines(locationId), decodingType: Lines.self) { result, response in
+      completion(result, response)
+    }
+  }
+  
+  public func getLineDetails(lineId: Int, completion: @escaping (Result<Line, QminderError>) -> Void) {
+    getLineDetails(lineId: lineId) { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func getLineDetails(lineId: Int,
+                             completion: @escaping (Result<Line, QminderError>, HTTPURLResponse?) -> Void) {
+    fetch(.line(lineId), decodingType: Line.self) { result, response in
+      completion(result, response)
+    }
+  }
+
+  public func getTicketDetails(ticketId: String, completion: @escaping (Result<Ticket, QminderError>) -> Void) {
+    getTicketDetails(ticketId: ticketId) { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func getTicketDetails(ticketId: String,
+                               completion: @escaping (Result<Ticket, QminderError>, HTTPURLResponse?) -> Void) {
+    fetch(.ticket(ticketId), decodingType: Ticket.self) { result, response in
+      completion(result, response)
+    }
+  }
+  
+  public func getUserDetails(userId: Int, completion: @escaping (Result<User, QminderError>) -> Void) {
+    getUserDetails(userId: userId) { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func getUserDetails(userId: Int,
+                             completion: @escaping (Result<User, QminderError>, HTTPURLResponse?) -> Void) {
+    fetch(.user(userId), decodingType: User.self) { result, response in
+      completion(result, response)
+    }
+  }
+  
+  public func getPairingCodeAndSecret(completion: @escaping (Result<TVPairingCode, QminderError>) -> Void) {
+    getPairingCodeAndSecret { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func getPairingCodeAndSecret(
+    completion: @escaping (Result<TVPairingCode, QminderError>, HTTPURLResponse?) -> Void) {
+    fetchTvPairing(.tvCode, decodingType: TVPairingCode.self) { result, response in
+      completion(result, response)
+    }
+  }
+  
+  public func pairTV(code: String,
+                     secret: String,
+                     completion: @escaping (Result<TVAPIData, QminderError>) -> Void) {
+    pairTV(code: code, secret: secret) { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func pairTV(code: String,
+                     secret: String,
+                     completion: @escaping (Result<TVAPIData, QminderError>, HTTPURLResponse?) -> Void) {
+    fetchTvPairing(.tvPairingStatus(code, ["secret": secret]), decodingType: TVAPIData.self) { result, response in
+      completion(result, response)
+    }
+  }
+  
+  public func tvDetails(id: Int, completion: @escaping (Result<TVDevice, QminderError>) -> Void) {
+    tvDetails(id: id) { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func tvDetails(id: Int, completion: @escaping (Result<TVDevice, QminderError>, HTTPURLResponse?) -> Void) {
+    fetch(.tvDetails(id), decodingType: TVDevice.self) { result, response in
+      completion(result, response)
+    }
+  }
+  
+  public func tvHeartbeat(id: Int, metadata: [String: Any],
+                          completion: @escaping (Result<Void?, QminderError>) -> Void) {
+    tvHeartbeat(id: id, metadata: metadata) { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func tvHeartbeat(id: Int, metadata: [String: Any],
+                          completion: @escaping (Result<Void?, QminderError>, HTTPURLResponse?) -> Void) {
+    fetch(.tvHeartbeat(id, metadata)) { result, response in
+      completion(result, response)
+    }
+  }
+  
+  public func tvEmptyState(id: Int, language: String,
+                           completion: @escaping (Result<EmptyState, QminderError>) -> Void) {
+    tvEmptyState(id: id, language: language) { result, _ in
+      completion(result)
+    }
+  }
+  
+  public func tvEmptyState(id: Int, language: String,
+                           completion: @escaping (Result<EmptyState, QminderError>, HTTPURLResponse?) -> Void) {
+    fetch(.tvEmptyState(id, ["language": language]), decodingType: EmptyState.self) { result, response in
+      completion(result, response)
+    }
+  }
+}
+  
 private extension QminderAPI {
-    /**
-     Fetch with responsable data
-     
-     - Parameters:
+  /**
+   Fetch with responsable data
+   
+   - Parameters:
      - endPoint: Qminder API endpoint
      - decodingType: Decoding data type
      - completion: Closure called when data is retrieved correctly
-     */
-    func fetch<T: ResponsableWithData>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
-                                       _ completion: @escaping (Result<T.Data, QminderError>, HTTPURLResponse?) -> Void) {
-        performRequestWith(endPoint) { result, response in
-            switch result {
-            case let .success(data):
-                completion(data.decode(decodingType), response)
-            case let .failure(error):
-                completion(Result(error), response)
-            }
-        }
+  */
+  func fetch<T: ResponsableWithData>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
+                                     _ completion: @escaping (Result<T.Data, QminderError>, HTTPURLResponse?) -> Void) {
+    performRequestWith(endPoint) { result, response in
+      switch result {
+      case let .success(data):
+        completion(data.decode(decodingType), response)
+      case let .failure(error):
+        completion(Result(error), response)
+      }
     }
-    
-    /**
-     Fetch with responsable
-     
-     - Parameters:
+  }
+  
+  /**
+   Fetch with responsable
+   
+   - Parameters:
      - endPoint: Qminder API endpoint
      - decodingType: Decoding data type
      - completion: Closure called when data is retrieved correctly
-     */
-    func fetch<T: Responsable>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
-                               _ completion: @escaping (Result<T, QminderError>, HTTPURLResponse?) -> Void) {
-        performRequestWith(endPoint) { result, response in
-            switch result {
-            case let .success(data):
-                completion(data.decode(decodingType), response)
-            case let .failure(error):
-                completion(Result(error), response)
-            }
-        }
+  */
+  func fetch<T: Responsable>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
+                             _ completion: @escaping (Result<T, QminderError>, HTTPURLResponse?) -> Void) {
+    performRequestWith(endPoint) { result, response in
+      switch result {
+      case let .success(data):
+        completion(data.decode(decodingType), response)
+      case let .failure(error):
+        completion(Result(error), response)
+      }
     }
-    
-    /**
-     Fetch tv pairing endpoint with responsable
-     
-     - Parameters:
-     - serverAddress: Qminer server address
-     - endPoint: Qminder endpoint
-     - decodingType: Decoding data type
-     - completion: Closure called when data is retrieved correctly
-     */
-    func fetchTvPairing<T: Responsable>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
-                                        _ completion: @escaping (Result<T, QminderError>, HTTPURLResponse?) -> Void) {
-        performTvPairingRequestWith(endPoint) { result, response in
-            switch result {
-            case let .success(data):
-                completion(data.decode(decodingType), response)
-            case let .failure(error):
-                completion(Result(error), response)
-            }
-        }
-    }
-    
-    /**
-     Fetch from API
-     
-     - Parameters:
+  }
+  
+  /**
+   Fetch from API
+   
+   - Parameters:
      - endPoint: Qminder API endpoint
      - completion: Closure called when data is retrieved correctly
-     */
-    func fetch(_ endPoint: QminderAPIEndpoint,
-               _ completion: @escaping (Result<Void?, QminderError>, HTTPURLResponse?) -> Void) {
-        performRequestWith(endPoint) { result, response in
-            switch result {
-            case .success:
-                completion(Result.success(nil), response)
-            case let .failure(error):
-                completion(Result(error), response)
-            }
-        }
+  */
+  func fetch(_ endPoint: QminderAPIEndpoint,
+             _ completion: @escaping (Result<Void?, QminderError>, HTTPURLResponse?) -> Void) {
+    performRequestWith(endPoint) { result, response in
+      switch result {
+      case .success:
+        completion(Result.success(nil), response)
+      case let .failure(error):
+        completion(Result(error), response)
+      }
     }
+  }
+
+  /**
+    Fetch tv pairing endpoint with responsable
     
-    /**
-     Perform request
-     
-     - Parameters:
+    - Parameters:
+      - endPoint: Qminder tv pairing code endpoint
+      - decodingType: Decoding data type
+      - completion: Closure called when data is retrieved correctly
+     */
+  func fetchTvPairing<T: Responsable>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
+                                      _ completion: @escaping (Result<T, QminderError>, HTTPURLResponse?) -> Void) {
+      performTvPairingRequestWith(endPoint) { result, response in
+          switch result {
+          case let .success(data):
+              completion(data.decode(decodingType), response)
+          case let .failure(error):
+              completion(Result(error), response)
+          }
+      }
+  }
+  
+  /**
+   Perform request
+   
+   - Parameters:
      - endPoint: Qminder API endpoint
      - completion: Closure called when data is retrieved correctly
-     */
-    func performRequestWith(_ endPoint: QminderAPIEndpoint,
-                            _ completion: @escaping (Result<Data, QminderError>, HTTPURLResponse?) -> Void) {
-        do {
-            let request = try endPoint.request(serverAddress: serverAddress, apiKey: apiKey)
-            
-            request.printCurlString()
-            
-            URLSession.shared.dataTask(with: request) { data, response, error in
-                let httpURLResponse = response as? HTTPURLResponse
-                self.queue.async {
-                    completion(self.parseResponse(data: data,
-                                                  response: response,
-                                                  error: error),
-                               httpURLResponse)
-                }
-            }.resume()
-        } catch {
-            completion(Result(error.qminderError), nil)
+  */
+  func performRequestWith(_ endPoint: QminderAPIEndpoint,
+                          _ completion: @escaping (Result<Data, QminderError>, HTTPURLResponse?) -> Void) {
+    do {
+      let request = try endPoint.request(serverAddress: serverAddress, apiKey: apiKey)
+      
+      request.printCurlString()
+      
+      URLSession.shared.dataTask(with: request) { data, response, error in
+        let httpURLResponse = response as? HTTPURLResponse
+        self.queue.async {
+          completion(self.parseResponse(data: data,
+                                        response: response,
+                                        error: error),
+                     httpURLResponse)
         }
+      }.resume()
+    } catch {
+      completion(Result(error.qminderError), nil)
     }
-    
-    /**
-     Perform unauthorised request
-     
-     - Parameters:
-     - serverAddress: Qminder server
-     - endPoint: Qminder endpoint
+  }
+
+  /**
+   Perform tv pairing code request
+   
+   - Parameters:
+     - endPoint: Qminder tv pairing code endpoint
      - completion: Closure called when data is retrieved correctly
-     */
-    func performTvPairingRequestWith(_ endPoint: QminderAPIEndpoint,
-                                     _ completion: @escaping (Result<Data, QminderError>, HTTPURLResponse?) -> Void) {
-        do {
-            let request = try endPoint.requestUnauthorised(serverAddress: tvPairingServerAddress)
-            
-            request.printCurlString()
-            
-            URLSession.shared.dataTask(with: request) { data, response, error in
-                let httpURLResponse = response as? HTTPURLResponse
-                self.queue.async {
-                    completion(self.parseResponse(data: data,
-                                                  response: response,
-                                                  error: error),
-                               httpURLResponse)
-                }
-            }.resume()
-        } catch {
-            completion(Result(error.qminderError), nil)
+  */
+  func performTvPairingRequestWith(_ endPoint: QminderAPIEndpoint,
+                                   _ completion: @escaping (Result<Data, QminderError>, HTTPURLResponse?) -> Void) {
+    do {
+      let request = try endPoint.requestUnauthorised(serverAddress: tvPairingServerAddress)
+      
+      request.printCurlString()
+      
+      URLSession.shared.dataTask(with: request) { data, response, error in
+        let httpURLResponse = response as? HTTPURLResponse
+        self.queue.async {
+          completion(self.parseResponse(data: data,
+                                        response: response,
+                                        error: error),
+                     httpURLResponse)
         }
+      }.resume()
+    } catch {
+      completion(Result(error.qminderError), nil)
     }
-    
-    /**
-     Parse response
-     
-     - Parameters:
+  }
+  
+  /**
+   Parse response
+   
+   - Parameters:
      - data: Data
      - response: URL response
      - error: Error
-     
-     - Returns: Result of data or Qmidner Error
-     */
-    func parseResponse(data: Data?, response: URLResponse?, error: Error?) -> Result<Data, QminderError> {
-        if let error = error {
-            return Result(.request(error))
-        } else {
-            
-            guard let httpResponse = response as? HTTPURLResponse, let resultData = data else {
-                return Result(.parseRequest)
-            }
-            
-            if httpResponse.statusCode != 200 {
-                return Result(.statusCode(httpResponse.statusCode))
-            }
-            
-            return Result(resultData)
-        }
-        
+   
+   - Returns: Result of data or Qmidner Error
+  */
+  func parseResponse(data: Data?, response: URLResponse?, error: Error?) -> Result<Data, QminderError> {
+    if let error = error {
+      return Result(.request(error))
+    } else {
+      
+      guard let httpResponse = response as? HTTPURLResponse, let resultData = data else {
+        return Result(.parseRequest)
+      }
+      
+      if httpResponse.statusCode != 200 {
+        return Result(.statusCode(httpResponse.statusCode))
+      }
+      
+      return Result(resultData)
     }
+    
+  }
 }

--- a/Sources/QminderAPI.swift
+++ b/Sources/QminderAPI.swift
@@ -10,268 +10,324 @@ import Foundation
 
 /// Qminder API
 public struct QminderAPI: QminderAPIProtocolResponse {
-  
-  /// Qminder API key
-  private var apiKey: String?
-  
-  /// Qminder API address
-  private var serverAddress: String
-  
-  /// Queue to return result in
-  private var queue = DispatchQueue.main
-  
-  public init(apiKey: String? = nil, serverAddress: String = "https://api.qminder.com/v1") {
-    self.apiKey = apiKey
-    self.serverAddress = serverAddress
-  }
-  
-  public func getLocationsList(completion: @escaping (Result<[Location], QminderError>) -> Void) {
-    getLocationsList { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func getLocationsList(completion: @escaping (Result<[Location], QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.locations, decodingType: Locations.self) { result, response in
-      completion(result, response)
-    }
-  }
     
-  public func getLocationLines(locationId: Int, completion: @escaping (Result<[Line], QminderError>) -> Void) {
-    getLocationLines(locationId: locationId) { result, _ in
-      completion(result)
+    /// Qminder API key
+    private var apiKey: String?
+    
+    /// Qminder API address
+    private var serverAddress: String
+    
+    /// Qminder TV Pairig Code address
+    private var tvPairingServerAddress: String
+    
+    /// Queue to return result in
+    private var queue = DispatchQueue.main
+    
+    public init(apiKey: String? = nil,
+                serverAddress: String = "https://api.qminder.com/v1",
+                tvPairingServerAddress: String = "https://tv.qminder.com") {
+        self.apiKey = apiKey
+        self.serverAddress = serverAddress
+        self.tvPairingServerAddress = tvPairingServerAddress
     }
-  }
-  
-  public func getLocationLines(locationId: Int,
-                               completion: @escaping (Result<[Line], QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.lines(locationId), decodingType: Lines.self) { result, response in
-      completion(result, response)
-    }
-  }
-  
-  public func getLineDetails(lineId: Int, completion: @escaping (Result<Line, QminderError>) -> Void) {
-    getLineDetails(lineId: lineId) { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func getLineDetails(lineId: Int,
-                             completion: @escaping (Result<Line, QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.line(lineId), decodingType: Line.self) { result, response in
-      completion(result, response)
-    }
-  }
-
-  public func getTicketDetails(ticketId: String, completion: @escaping (Result<Ticket, QminderError>) -> Void) {
-    getTicketDetails(ticketId: ticketId) { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func getTicketDetails(ticketId: String,
-                               completion: @escaping (Result<Ticket, QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.ticket(ticketId), decodingType: Ticket.self) { result, response in
-      completion(result, response)
-    }
-  }
-  
-  public func getUserDetails(userId: Int, completion: @escaping (Result<User, QminderError>) -> Void) {
-    getUserDetails(userId: userId) { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func getUserDetails(userId: Int,
-                             completion: @escaping (Result<User, QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.user(userId), decodingType: User.self) { result, response in
-      completion(result, response)
-    }
-  }
-  
-  public func getPairingCodeAndSecret(completion: @escaping (Result<TVPairingCode, QminderError>) -> Void) {
-    getPairingCodeAndSecret { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func getPairingCodeAndSecret(
-    completion: @escaping (Result<TVPairingCode, QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.tvCode, decodingType: TVPairingCode.self) { result, response in
-      completion(result, response)
-    }
-  }
-  
-  public func pairTV(code: String,
-                     secret: String,
-                     completion: @escaping (Result<TVAPIData, QminderError>) -> Void) {
-    pairTV(code: code, secret: secret) { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func pairTV(code: String,
-                     secret: String,
-                     completion: @escaping (Result<TVAPIData, QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.tvPairingStatus(code, ["secret": secret]), decodingType: TVAPIData.self) { result, response in
-      completion(result, response)
-    }
-  }
-  
-  public func tvDetails(id: Int, completion: @escaping (Result<TVDevice, QminderError>) -> Void) {
-    tvDetails(id: id) { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func tvDetails(id: Int, completion: @escaping (Result<TVDevice, QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.tvDetails(id), decodingType: TVDevice.self) { result, response in
-      completion(result, response)
-    }
-  }
-  
-  public func tvHeartbeat(id: Int, metadata: [String: Any],
-                          completion: @escaping (Result<Void?, QminderError>) -> Void) {
-    tvHeartbeat(id: id, metadata: metadata) { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func tvHeartbeat(id: Int, metadata: [String: Any],
-                          completion: @escaping (Result<Void?, QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.tvHeartbeat(id, metadata)) { result, response in
-      completion(result, response)
-    }
-  }
-  
-  public func tvEmptyState(id: Int, language: String,
-                           completion: @escaping (Result<EmptyState, QminderError>) -> Void) {
-    tvEmptyState(id: id, language: language) { result, _ in
-      completion(result)
-    }
-  }
-  
-  public func tvEmptyState(id: Int, language: String,
-                           completion: @escaping (Result<EmptyState, QminderError>, HTTPURLResponse?) -> Void) {
-    fetch(.tvEmptyState(id, ["language": language]), decodingType: EmptyState.self) { result, response in
-      completion(result, response)
-    }
-  }
-}
-  
-private extension QminderAPI {
-  /**
-   Fetch with responsable data
-   
-   - Parameters:
-     - endPoint: Qminder API endpoint
-     - decodingType: Decoding data type
-     - completion: Closure called when data is retrieved correctly
-  */
-  func fetch<T: ResponsableWithData>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
-                                     _ completion: @escaping (Result<T.Data, QminderError>, HTTPURLResponse?) -> Void) {
-    performRequestWith(endPoint) { result, response in
-      switch result {
-      case let .success(data):
-        completion(data.decode(decodingType), response)
-      case let .failure(error):
-        completion(Result(error), response)
-      }
-    }
-  }
-  
-  /**
-   Fetch with responsable
-   
-   - Parameters:
-     - endPoint: Qminder API endpoint
-     - decodingType: Decoding data type
-     - completion: Closure called when data is retrieved correctly
-  */
-  func fetch<T: Responsable>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
-                             _ completion: @escaping (Result<T, QminderError>, HTTPURLResponse?) -> Void) {
-    performRequestWith(endPoint) { result, response in
-      switch result {
-      case let .success(data):
-        completion(data.decode(decodingType), response)
-      case let .failure(error):
-        completion(Result(error), response)
-      }
-    }
-  }
-  
-  /**
-   Fetch from API
-   
-   - Parameters:
-     - endPoint: Qminder API endpoint
-     - completion: Closure called when data is retrieved correctly
-  */
-  func fetch(_ endPoint: QminderAPIEndpoint,
-             _ completion: @escaping (Result<Void?, QminderError>, HTTPURLResponse?) -> Void) {
-    performRequestWith(endPoint) { result, response in
-      switch result {
-      case .success:
-        completion(Result.success(nil), response)
-      case let .failure(error):
-        completion(Result(error), response)
-      }
-    }
-  }
-  
-  /**
-   Perform request
-   
-   - Parameters:
-     - endPoint: Qminder API endpoint
-     - completion: Closure called when data is retrieved correctly
-  */
-  func performRequestWith(_ endPoint: QminderAPIEndpoint,
-                          _ completion: @escaping (Result<Data, QminderError>, HTTPURLResponse?) -> Void) {
-    do {
-      let request = try endPoint.request(serverAddress: serverAddress, apiKey: apiKey)
-      
-      request.printCurlString()
-      
-      URLSession.shared.dataTask(with: request) { data, response, error in
-        let httpURLResponse = response as? HTTPURLResponse
-        self.queue.async {
-          completion(self.parseResponse(data: data,
-                                        response: response,
-                                        error: error),
-                     httpURLResponse)
+    
+    public func getLocationsList(completion: @escaping (Result<[Location], QminderError>) -> Void) {
+        getLocationsList { result, _ in
+            completion(result)
         }
-      }.resume()
-    } catch {
-      completion(Result(error.qminderError), nil)
     }
-  }
-  
-  /**
-   Parse response
-   
-   - Parameters:
+    
+    public func getLocationsList(completion: @escaping (Result<[Location], QminderError>, HTTPURLResponse?) -> Void) {
+        fetch(.locations, decodingType: Locations.self) { result, response in
+            completion(result, response)
+        }
+    }
+    
+    public func getLocationLines(locationId: Int, completion: @escaping (Result<[Line], QminderError>) -> Void) {
+        getLocationLines(locationId: locationId) { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func getLocationLines(locationId: Int,
+                                 completion: @escaping (Result<[Line], QminderError>, HTTPURLResponse?) -> Void) {
+        fetch(.lines(locationId), decodingType: Lines.self) { result, response in
+            completion(result, response)
+        }
+    }
+    
+    public func getLineDetails(lineId: Int, completion: @escaping (Result<Line, QminderError>) -> Void) {
+        getLineDetails(lineId: lineId) { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func getLineDetails(lineId: Int,
+                               completion: @escaping (Result<Line, QminderError>, HTTPURLResponse?) -> Void) {
+        fetch(.line(lineId), decodingType: Line.self) { result, response in
+            completion(result, response)
+        }
+    }
+    
+    public func getTicketDetails(ticketId: String, completion: @escaping (Result<Ticket, QminderError>) -> Void) {
+        getTicketDetails(ticketId: ticketId) { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func getTicketDetails(ticketId: String,
+                                 completion: @escaping (Result<Ticket, QminderError>, HTTPURLResponse?) -> Void) {
+        fetch(.ticket(ticketId), decodingType: Ticket.self) { result, response in
+            completion(result, response)
+        }
+    }
+    
+    public func getUserDetails(userId: Int, completion: @escaping (Result<User, QminderError>) -> Void) {
+        getUserDetails(userId: userId) { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func getUserDetails(userId: Int,
+                               completion: @escaping (Result<User, QminderError>, HTTPURLResponse?) -> Void) {
+        fetch(.user(userId), decodingType: User.self) { result, response in
+            completion(result, response)
+        }
+    }
+    
+    public func getPairingCodeAndSecret(completion: @escaping (Result<TVPairingCode, QminderError>) -> Void) {
+        getPairingCodeAndSecret { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func getPairingCodeAndSecret(
+        completion: @escaping (Result<TVPairingCode, QminderError>, HTTPURLResponse?) -> Void) {
+            fetchTvPairing(.tvCode, decodingType: TVPairingCode.self) { result, response in
+                completion(result, response)
+            }
+        }
+    
+    public func pairTV(code: String,
+                       secret: String,
+                       completion: @escaping (Result<TVAPIData, QminderError>) -> Void) {
+        pairTV(code: code, secret: secret) { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func pairTV(code: String,
+                       secret: String,
+                       completion: @escaping (Result<TVAPIData, QminderError>, HTTPURLResponse?) -> Void) {
+        fetchTvPairing(.tvPairingStatus(code, ["secret": secret]), decodingType: TVAPIData.self) { result, response in
+            completion(result, response)
+        }
+    }
+    
+    public func tvDetails(id: Int, completion: @escaping (Result<TVDevice, QminderError>) -> Void) {
+        tvDetails(id: id) { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func tvDetails(id: Int, completion: @escaping (Result<TVDevice, QminderError>, HTTPURLResponse?) -> Void) {
+        fetch(.tvDetails(id), decodingType: TVDevice.self) { result, response in
+            completion(result, response)
+        }
+    }
+    
+    public func tvHeartbeat(id: Int, metadata: [String: Any],
+                            completion: @escaping (Result<Void?, QminderError>) -> Void) {
+        tvHeartbeat(id: id, metadata: metadata) { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func tvHeartbeat(id: Int, metadata: [String: Any],
+                            completion: @escaping (Result<Void?, QminderError>, HTTPURLResponse?) -> Void) {
+        fetch(.tvHeartbeat(id, metadata)) { result, response in
+            completion(result, response)
+        }
+    }
+    
+    public func tvEmptyState(id: Int, language: String,
+                             completion: @escaping (Result<EmptyState, QminderError>) -> Void) {
+        tvEmptyState(id: id, language: language) { result, _ in
+            completion(result)
+        }
+    }
+    
+    public func tvEmptyState(id: Int, language: String,
+                             completion: @escaping (Result<EmptyState, QminderError>, HTTPURLResponse?) -> Void) {
+        fetch(.tvEmptyState(id, ["language": language]), decodingType: EmptyState.self) { result, response in
+            completion(result, response)
+        }
+    }
+}
+
+private extension QminderAPI {
+    /**
+     Fetch with responsable data
+     
+     - Parameters:
+     - endPoint: Qminder API endpoint
+     - decodingType: Decoding data type
+     - completion: Closure called when data is retrieved correctly
+     */
+    func fetch<T: ResponsableWithData>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
+                                       _ completion: @escaping (Result<T.Data, QminderError>, HTTPURLResponse?) -> Void) {
+        performRequestWith(endPoint) { result, response in
+            switch result {
+            case let .success(data):
+                completion(data.decode(decodingType), response)
+            case let .failure(error):
+                completion(Result(error), response)
+            }
+        }
+    }
+    
+    /**
+     Fetch with responsable
+     
+     - Parameters:
+     - endPoint: Qminder API endpoint
+     - decodingType: Decoding data type
+     - completion: Closure called when data is retrieved correctly
+     */
+    func fetch<T: Responsable>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
+                               _ completion: @escaping (Result<T, QminderError>, HTTPURLResponse?) -> Void) {
+        performRequestWith(endPoint) { result, response in
+            switch result {
+            case let .success(data):
+                completion(data.decode(decodingType), response)
+            case let .failure(error):
+                completion(Result(error), response)
+            }
+        }
+    }
+    
+    /**
+     Fetch tv pairing endpoint with responsable
+     
+     - Parameters:
+     - serverAddress: Qminer server address
+     - endPoint: Qminder endpoint
+     - decodingType: Decoding data type
+     - completion: Closure called when data is retrieved correctly
+     */
+    func fetchTvPairing<T: Responsable>(_ endPoint: QminderAPIEndpoint, decodingType: T.Type,
+                                        _ completion: @escaping (Result<T, QminderError>, HTTPURLResponse?) -> Void) {
+        performTvPairingRequestWith(endPoint) { result, response in
+            switch result {
+            case let .success(data):
+                completion(data.decode(decodingType), response)
+            case let .failure(error):
+                completion(Result(error), response)
+            }
+        }
+    }
+    
+    /**
+     Fetch from API
+     
+     - Parameters:
+     - endPoint: Qminder API endpoint
+     - completion: Closure called when data is retrieved correctly
+     */
+    func fetch(_ endPoint: QminderAPIEndpoint,
+               _ completion: @escaping (Result<Void?, QminderError>, HTTPURLResponse?) -> Void) {
+        performRequestWith(endPoint) { result, response in
+            switch result {
+            case .success:
+                completion(Result.success(nil), response)
+            case let .failure(error):
+                completion(Result(error), response)
+            }
+        }
+    }
+    
+    /**
+     Perform request
+     
+     - Parameters:
+     - endPoint: Qminder API endpoint
+     - completion: Closure called when data is retrieved correctly
+     */
+    func performRequestWith(_ endPoint: QminderAPIEndpoint,
+                            _ completion: @escaping (Result<Data, QminderError>, HTTPURLResponse?) -> Void) {
+        do {
+            let request = try endPoint.request(serverAddress: serverAddress, apiKey: apiKey)
+            
+            request.printCurlString()
+            
+            URLSession.shared.dataTask(with: request) { data, response, error in
+                let httpURLResponse = response as? HTTPURLResponse
+                self.queue.async {
+                    completion(self.parseResponse(data: data,
+                                                  response: response,
+                                                  error: error),
+                               httpURLResponse)
+                }
+            }.resume()
+        } catch {
+            completion(Result(error.qminderError), nil)
+        }
+    }
+    
+    /**
+     Perform unauthorised request
+     
+     - Parameters:
+     - serverAddress: Qminder server
+     - endPoint: Qminder endpoint
+     - completion: Closure called when data is retrieved correctly
+     */
+    func performTvPairingRequestWith(_ endPoint: QminderAPIEndpoint,
+                                     _ completion: @escaping (Result<Data, QminderError>, HTTPURLResponse?) -> Void) {
+        do {
+            let request = try endPoint.requestUnauthorised(serverAddress: tvPairingServerAddress)
+            
+            request.printCurlString()
+            
+            URLSession.shared.dataTask(with: request) { data, response, error in
+                let httpURLResponse = response as? HTTPURLResponse
+                self.queue.async {
+                    completion(self.parseResponse(data: data,
+                                                  response: response,
+                                                  error: error),
+                               httpURLResponse)
+                }
+            }.resume()
+        } catch {
+            completion(Result(error.qminderError), nil)
+        }
+    }
+    
+    /**
+     Parse response
+     
+     - Parameters:
      - data: Data
      - response: URL response
      - error: Error
-   
-   - Returns: Result of data or Qmidner Error
-  */
-  func parseResponse(data: Data?, response: URLResponse?, error: Error?) -> Result<Data, QminderError> {
-    if let error = error {
-      return Result(.request(error))
-    } else {
-      
-      guard let httpResponse = response as? HTTPURLResponse, let resultData = data else {
-        return Result(.parseRequest)
-      }
-      
-      if httpResponse.statusCode != 200 {
-        return Result(.statusCode(httpResponse.statusCode))
-      }
-      
-      return Result(resultData)
+     
+     - Returns: Result of data or Qmidner Error
+     */
+    func parseResponse(data: Data?, response: URLResponse?, error: Error?) -> Result<Data, QminderError> {
+        if let error = error {
+            return Result(.request(error))
+        } else {
+            
+            guard let httpResponse = response as? HTTPURLResponse, let resultData = data else {
+                return Result(.parseRequest)
+            }
+            
+            if httpResponse.statusCode != 200 {
+                return Result(.statusCode(httpResponse.statusCode))
+            }
+            
+            return Result(resultData)
+        }
+        
     }
-    
-  }
 }

--- a/Sources/QminderAPIEndpoint.swift
+++ b/Sources/QminderAPIEndpoint.swift
@@ -9,88 +9,79 @@
 import Foundation
 
 enum QminderAPIEndpoint: QminderAPIEndpointProtocol {
-  case locations
-  case location(Int)
-  case lines(Int)
-  case users(Int)
-  case desks(Int)
-  case line(Int)
-  case tickets([String: Any])
-  case ticket(String)
-  case user(Int)
-  case tvCode
-  case tvPairingStatus(String, [String: Any])
-  case tvDetails(Int)
-  case tvHeartbeat(Int, [String: Any])
-  case tvEmptyState(Int, [String: Any])
-  
-  var path: String {
-    switch self {
-    case .locations:
-      return "/locations/"
-    case let .location(locationId):
-      return "/locations/\(locationId)"
-    case let .lines(locationId):
-      return "/locations/\(locationId)/lines"
-    case let .users(locationId):
-      return "/locations/\(locationId)/users"
-    case let .desks(locationId):
-      return "/locations/\(locationId)/desks"
-    case let .line(lineId):
-      return "/lines/\(lineId)"
-    case .tickets:
-      return "/tickets/search"
-    case let .ticket(ticketId):
-      return "/tickets/\(ticketId)"
-    case let .user(userId):
-      return "/users/\(userId)"
-    case .tvCode:
-      return "/tv/code"
-    case let .tvPairingStatus(code, _):
-      return "/tv/code/\(code)"
-    case let .tvDetails(tvId):
-      return "/tv/\(tvId)"
-    case let .tvHeartbeat(tvId, _):
-      return "/tv/\(tvId)/heartbeat"
-    case let .tvEmptyState(tvId, _):
-      return "/tv/\(tvId)/emptystate"
+    case locations
+    case location(Int)
+    case lines(Int)
+    case users(Int)
+    case desks(Int)
+    case line(Int)
+    case tickets([String: Any])
+    case ticket(String)
+    case user(Int)
+    case tvCode
+    case tvPairingStatus(String, [String: Any])
+    case tvDetails(Int)
+    case tvHeartbeat(Int, [String: Any])
+    case tvEmptyState(Int, [String: Any])
+    
+    var path: String {
+        switch self {
+        case .locations:
+            return "/locations/"
+        case let .location(locationId):
+            return "/locations/\(locationId)"
+        case let .lines(locationId):
+            return "/locations/\(locationId)/lines"
+        case let .users(locationId):
+            return "/locations/\(locationId)/users"
+        case let .desks(locationId):
+            return "/locations/\(locationId)/desks"
+        case let .line(lineId):
+            return "/lines/\(lineId)"
+        case .tickets:
+            return "/tickets/search"
+        case let .ticket(ticketId):
+            return "/tickets/\(ticketId)"
+        case let .user(userId):
+            return "/users/\(userId)"
+        case .tvCode:
+            return "/tv/code"
+        case let .tvPairingStatus(code, _):
+            return "/tv/code/\(code)"
+        case let .tvDetails(tvId):
+            return "/tv/\(tvId)"
+        case let .tvHeartbeat(tvId, _):
+            return "/tv/\(tvId)/heartbeat"
+        case let .tvEmptyState(tvId, _):
+            return "/tv/\(tvId)/emptystate"
+        }
     }
-  }
-  
-  var parameters: [String: Any] {
-    switch self {
-    case let .tickets(parameters), let .tvPairingStatus(_, parameters),
-         let .tvHeartbeat(_, parameters), let .tvEmptyState(_, parameters) :
-      return parameters
-    default:
-      return [:]
+    
+    var parameters: [String: Any] {
+        switch self {
+        case let .tickets(parameters), let .tvPairingStatus(_, parameters),
+            let .tvHeartbeat(_, parameters), let .tvEmptyState(_, parameters) :
+            return parameters
+        default:
+            return [:]
+        }
     }
-  }
-  
-  var method: HTTPMethod {
-    switch self {
-    case .tvHeartbeat:
-      return .post
-    default:
-      return .get
+    
+    var method: HTTPMethod {
+        switch self {
+        case .tvHeartbeat:
+            return .post
+        default:
+            return .get
+        }
     }
-  }
-  
-  var apiKeyNeeded: Bool {
-    switch self {
-    case .tvCode, .tvPairingStatus:
-      return false
-    default:
-      return true
+    
+    var encoding: ParameterEncoding {
+        switch self {
+        case .tvHeartbeat:
+            return .json
+        default:
+            return .none
+        }
     }
-  }
-  
-  var encoding: ParameterEncoding {
-    switch self {
-    case .tvHeartbeat:
-      return .json
-    default:
-      return .none
-    }
-  }
 }

--- a/Sources/QminderAPIEndpoint.swift
+++ b/Sources/QminderAPIEndpoint.swift
@@ -9,79 +9,79 @@
 import Foundation
 
 enum QminderAPIEndpoint: QminderAPIEndpointProtocol {
-    case locations
-    case location(Int)
-    case lines(Int)
-    case users(Int)
-    case desks(Int)
-    case line(Int)
-    case tickets([String: Any])
-    case ticket(String)
-    case user(Int)
-    case tvCode
-    case tvPairingStatus(String, [String: Any])
-    case tvDetails(Int)
-    case tvHeartbeat(Int, [String: Any])
-    case tvEmptyState(Int, [String: Any])
-    
-    var path: String {
-        switch self {
-        case .locations:
-            return "/locations/"
-        case let .location(locationId):
-            return "/locations/\(locationId)"
-        case let .lines(locationId):
-            return "/locations/\(locationId)/lines"
-        case let .users(locationId):
-            return "/locations/\(locationId)/users"
-        case let .desks(locationId):
-            return "/locations/\(locationId)/desks"
-        case let .line(lineId):
-            return "/lines/\(lineId)"
-        case .tickets:
-            return "/tickets/search"
-        case let .ticket(ticketId):
-            return "/tickets/\(ticketId)"
-        case let .user(userId):
-            return "/users/\(userId)"
-        case .tvCode:
-            return "/tv/code"
-        case let .tvPairingStatus(code, _):
-            return "/tv/code/\(code)"
-        case let .tvDetails(tvId):
-            return "/tv/\(tvId)"
-        case let .tvHeartbeat(tvId, _):
-            return "/tv/\(tvId)/heartbeat"
-        case let .tvEmptyState(tvId, _):
-            return "/tv/\(tvId)/emptystate"
-        }
+  case locations
+  case location(Int)
+  case lines(Int)
+  case users(Int)
+  case desks(Int)
+  case line(Int)
+  case tickets([String: Any])
+  case ticket(String)
+  case user(Int)
+  case tvCode
+  case tvPairingStatus(String, [String: Any])
+  case tvDetails(Int)
+  case tvHeartbeat(Int, [String: Any])
+  case tvEmptyState(Int, [String: Any])
+  
+  var path: String {
+    switch self {
+    case .locations:
+      return "/locations/"
+    case let .location(locationId):
+      return "/locations/\(locationId)"
+    case let .lines(locationId):
+      return "/locations/\(locationId)/lines"
+    case let .users(locationId):
+      return "/locations/\(locationId)/users"
+    case let .desks(locationId):
+      return "/locations/\(locationId)/desks"
+    case let .line(lineId):
+      return "/lines/\(lineId)"
+    case .tickets:
+      return "/tickets/search"
+    case let .ticket(ticketId):
+      return "/tickets/\(ticketId)"
+    case let .user(userId):
+      return "/users/\(userId)"
+    case .tvCode:
+      return "/tv/code"
+    case let .tvPairingStatus(code, _):
+      return "/tv/code/\(code)"
+    case let .tvDetails(tvId):
+      return "/tv/\(tvId)"
+    case let .tvHeartbeat(tvId, _):
+      return "/tv/\(tvId)/heartbeat"
+    case let .tvEmptyState(tvId, _):
+      return "/tv/\(tvId)/emptystate"
     }
-    
-    var parameters: [String: Any] {
-        switch self {
-        case let .tickets(parameters), let .tvPairingStatus(_, parameters),
-            let .tvHeartbeat(_, parameters), let .tvEmptyState(_, parameters) :
-            return parameters
-        default:
-            return [:]
-        }
+  }
+  
+  var parameters: [String: Any] {
+    switch self {
+    case let .tickets(parameters), let .tvPairingStatus(_, parameters),
+         let .tvHeartbeat(_, parameters), let .tvEmptyState(_, parameters) :
+      return parameters
+    default:
+      return [:]
     }
-    
-    var method: HTTPMethod {
-        switch self {
-        case .tvHeartbeat:
-            return .post
-        default:
-            return .get
-        }
+  }
+  
+  var method: HTTPMethod {
+    switch self {
+    case .tvHeartbeat:
+      return .post
+    default:
+      return .get
     }
-    
-    var encoding: ParameterEncoding {
-        switch self {
-        case .tvHeartbeat:
-            return .json
-        default:
-            return .none
-        }
+  }
+  
+  var encoding: ParameterEncoding {
+    switch self {
+    case .tvHeartbeat:
+      return .json
+    default:
+      return .none
     }
+  }
 }

--- a/Sources/QminderAPIEndpoint.swift
+++ b/Sources/QminderAPIEndpoint.swift
@@ -45,9 +45,9 @@ enum QminderAPIEndpoint: QminderAPIEndpointProtocol {
     case let .user(userId):
       return "/users/\(userId)"
     case .tvCode:
-      return "/tv/code"
+      return "/code"
     case let .tvPairingStatus(code, _):
-      return "/tv/code/\(code)"
+      return "/code/\(code)"
     case let .tvDetails(tvId):
       return "/tv/\(tvId)"
     case let .tvHeartbeat(tvId, _):

--- a/Sources/QminderAPIEndpointProtocol.swift
+++ b/Sources/QminderAPIEndpointProtocol.swift
@@ -64,13 +64,11 @@ extension QminderAPIEndpointProtocol {
     var request = URLRequest(url: url.url!)
     request.httpMethod = method.rawValue
 
-    if apiKeyNeeded {
-      guard let key = apiKey else {
-        throw QminderError.apiKeyNotSet
-      }
-
-      request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
+    guard let key = apiKey else {
+      throw QminderError.apiKeyNotSet
     }
+
+    request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
 
     if encoding == .json {
       let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])

--- a/Sources/QminderAPIEndpointProtocol.swift
+++ b/Sources/QminderAPIEndpointProtocol.swift
@@ -10,74 +10,76 @@ import Foundation
 
 /// Qminder API endpoint protocol
 protocol QminderAPIEndpointProtocol {
-    
-    /// Endpoint path
-    var path: String { get }
-    
-    /// Parameters
-    var parameters: [String: Any] { get }
-    
-    /// HTTP methods
-    var method: HTTPMethod { get }
-    
-    /// Encoding: none or JSON
-    var encoding: ParameterEncoding { get }
+
+  /// Endpoint path
+  var path: String { get }
+
+  /// Parameters
+  var parameters: [String: Any] { get }
+
+  /// HTTP methods
+  var method: HTTPMethod { get }
+
+  /// Encoding: none or JSON
+  var encoding: ParameterEncoding { get }
 }
 
 extension QminderAPIEndpointProtocol {
-    
-    func requestUnauthorised(serverAddress: String) throws -> URLRequest {
-        var url = URLComponents(string: "\(serverAddress)\(path)")!
-        
-        if encoding == .none {
-            url.queryItems = parameters.map {
-                URLQueryItem(name: $0, value: String(describing: $1))
-            }
-        }
-        
-        var request = URLRequest(url: url.url!)
-        request.httpMethod = method.rawValue
-        
-        if encoding == .json {
-            let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
-            
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
-            request.httpBody = jsonData
-        }
-        
-        return request
+
+  func requestUnauthorised(serverAddress: String) throws -> URLRequest {
+    var url = URLComponents(string: "\(serverAddress)\(path)")!
+
+    if encoding == .none {
+      url.queryItems = parameters.map {
+          URLQueryItem(name: $0, value: String(describing: $1))
+      }
     }
-    
-    /**
-     Create request
-     */
-    internal func request(serverAddress: String, apiKey: String?) throws -> URLRequest {
-        var url = URLComponents(string: "\(serverAddress)\(path)")!
-        
-        if encoding == .none {
-            url.queryItems = parameters.map {
-                URLQueryItem(name: $0, value: String(describing: $1))
-            }
-        }
-        
-        var request = URLRequest(url: url.url!)
-        request.httpMethod = method.rawValue
-        
-        guard let key = apiKey else {
-            throw QminderError.apiKeyNotSet
-        }
-        
-        request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
-        
-        if encoding == .json {
-            let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
-            
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
-            request.httpBody = jsonData
-        }
-        
-        return request
+
+    var request = URLRequest(url: url.url!)
+    request.httpMethod = method.rawValue
+
+    if encoding == .json {
+      let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
+
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.setValue("application/json", forHTTPHeaderField: "Accept")
+      request.httpBody = jsonData
     }
+
+    return request
+  }
+
+  /**
+   Create request
+  */
+  internal func request(serverAddress: String, apiKey: String?) throws -> URLRequest {
+    var url = URLComponents(string: "\(serverAddress)\(path)")!
+
+    if encoding == .none {
+      url.queryItems = parameters.map {
+        URLQueryItem(name: $0, value: String(describing: $1))
+      }
+    }
+
+    var request = URLRequest(url: url.url!)
+    request.httpMethod = method.rawValue
+
+    if apiKeyNeeded {
+      guard let key = apiKey else {
+        throw QminderError.apiKeyNotSet
+      }
+
+      request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
+    }
+
+    if encoding == .json {
+      let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
+
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.setValue("application/json", forHTTPHeaderField: "Accept")
+      request.httpBody = jsonData
+    }
+
+    return request
+  }
 }

--- a/Sources/QminderAPIEndpointProtocol.swift
+++ b/Sources/QminderAPIEndpointProtocol.swift
@@ -10,56 +10,79 @@ import Foundation
 
 /// Qminder API endpoint protocol
 protocol QminderAPIEndpointProtocol {
-  
-  /// Endpoint path
-  var path: String { get }
-  
-  /// Parameters
-  var parameters: [String: Any] { get }
-  
-  /// HTTP methods
-  var method: HTTPMethod { get }
-  
-  /// Is API key needed
-  var apiKeyNeeded: Bool { get }
-  
-  /// Encoding: none or JSON
-  var encoding: ParameterEncoding { get }
+    
+    /// Endpoint path
+    var path: String { get }
+    
+    /// Parameters
+    var parameters: [String: Any] { get }
+    
+    /// HTTP methods
+    var method: HTTPMethod { get }
+    
+    /// Is API key needed
+    var apiKeyNeeded: Bool { get }
+    
+    /// Encoding: none or JSON
+    var encoding: ParameterEncoding { get }
 }
 
 extension QminderAPIEndpointProtocol {
-  
-  /**
-   Create request
-  */
-  internal func request(serverAddress: String, apiKey: String?) throws -> URLRequest {
-    var url = URLComponents(string: "\(serverAddress)\(path)")!
     
-    if encoding == .none {
-      url.queryItems = parameters.map {
-        URLQueryItem(name: $0, value: String(describing: $1))
-      }
+    func requestUnauthorised(serverAddress: String) throws -> URLRequest {
+        var url = URLComponents(string: "\(serverAddress)\(path)")!
+        
+        if encoding == .none {
+            url.queryItems = parameters.map {
+                URLQueryItem(name: $0, value: String(describing: $1))
+            }
+        }
+        
+        var request = URLRequest(url: url.url!)
+        request.httpMethod = method.rawValue
+        
+        if encoding == .json {
+            let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
+            
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.httpBody = jsonData
+        }
+        
+        return request
     }
     
-    var request = URLRequest(url: url.url!)
-    request.httpMethod = method.rawValue
-    
-    if apiKeyNeeded {
-      guard let key = apiKey else {
-        throw QminderError.apiKeyNotSet
-      }
-      
-      request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
+    /**
+     Create request
+     */
+    internal func request(serverAddress: String, apiKey: String?) throws -> URLRequest {
+        var url = URLComponents(string: "\(serverAddress)\(path)")!
+        
+        if encoding == .none {
+            url.queryItems = parameters.map {
+                URLQueryItem(name: $0, value: String(describing: $1))
+            }
+        }
+        
+        var request = URLRequest(url: url.url!)
+        request.httpMethod = method.rawValue
+        
+        if apiKeyNeeded {
+            guard let key = apiKey else {
+                throw QminderError.apiKeyNotSet
+            }
+            
+            request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
+        }
+        
+        if encoding == .json {
+            let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
+            
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.httpBody = jsonData
+        }
+        
+        return request
     }
-    
-    if encoding == .json {
-      let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
-      
-      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-      request.setValue("application/json", forHTTPHeaderField: "Accept")
-      request.httpBody = jsonData
-    }
-    
-    return request
-  }
 }

--- a/Sources/QminderAPIEndpointProtocol.swift
+++ b/Sources/QminderAPIEndpointProtocol.swift
@@ -20,9 +20,6 @@ protocol QminderAPIEndpointProtocol {
     /// HTTP methods
     var method: HTTPMethod { get }
     
-    /// Is API key needed
-    var apiKeyNeeded: Bool { get }
-    
     /// Encoding: none or JSON
     var encoding: ParameterEncoding { get }
 }
@@ -67,13 +64,11 @@ extension QminderAPIEndpointProtocol {
         var request = URLRequest(url: url.url!)
         request.httpMethod = method.rawValue
         
-        if apiKeyNeeded {
-            guard let key = apiKey else {
-                throw QminderError.apiKeyNotSet
-            }
-            
-            request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
+        guard let key = apiKey else {
+            throw QminderError.apiKeyNotSet
         }
+        
+        request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
         
         if encoding == .json {
             let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])

--- a/Sources/QminderAPIEndpointProtocol.swift
+++ b/Sources/QminderAPIEndpointProtocol.swift
@@ -10,74 +10,74 @@ import Foundation
 
 /// Qminder API endpoint protocol
 protocol QminderAPIEndpointProtocol {
-
+  
   /// Endpoint path
   var path: String { get }
-
+  
   /// Parameters
   var parameters: [String: Any] { get }
-
+  
   /// HTTP methods
   var method: HTTPMethod { get }
-
+  
   /// Encoding: none or JSON
   var encoding: ParameterEncoding { get }
 }
 
 extension QminderAPIEndpointProtocol {
-
+  
   func requestUnauthorised(serverAddress: String) throws -> URLRequest {
     var url = URLComponents(string: "\(serverAddress)\(path)")!
-
+    
     if encoding == .none {
       url.queryItems = parameters.map {
           URLQueryItem(name: $0, value: String(describing: $1))
       }
     }
-
+    
     var request = URLRequest(url: url.url!)
     request.httpMethod = method.rawValue
-
+    
     if encoding == .json {
       let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
-
+      
       request.setValue("application/json", forHTTPHeaderField: "Content-Type")
       request.setValue("application/json", forHTTPHeaderField: "Accept")
       request.httpBody = jsonData
     }
-
+    
     return request
   }
-
+  
   /**
    Create request
   */
   internal func request(serverAddress: String, apiKey: String?) throws -> URLRequest {
     var url = URLComponents(string: "\(serverAddress)\(path)")!
-
+    
     if encoding == .none {
       url.queryItems = parameters.map {
         URLQueryItem(name: $0, value: String(describing: $1))
       }
     }
-
+    
     var request = URLRequest(url: url.url!)
     request.httpMethod = method.rawValue
-
+    
     guard let key = apiKey else {
       throw QminderError.apiKeyNotSet
     }
-
+    
     request.setValue(key, forHTTPHeaderField: "X-Qminder-REST-API-Key")
-
+    
     if encoding == .json {
       let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: [])
-
+      
       request.setValue("application/json", forHTTPHeaderField: "Content-Type")
       request.setValue("application/json", forHTTPHeaderField: "Accept")
       request.httpBody = jsonData
     }
-
+    
     return request
   }
 }

--- a/Sources/QminderAPIProtocol.swift
+++ b/Sources/QminderAPIProtocol.swift
@@ -16,7 +16,8 @@ public protocol QminderAPIProtocol {
   /// - Parameters:
   ///   - apiKey: Qminder API key
   ///   - serverAddress: Optional server address (used for tests)
-  init(apiKey: String?, serverAddress: String)
+  ///   - tvPairingServerAddress: TV Code Pairing server address
+  init(apiKey: String?, serverAddress: String, tvPairingServerAddress: String)
   
   // MARK: - Location
   /// Get location list


### PR DESCRIPTION
## Description of the change

This PR changes api so that `tv/code` and `tv/code/{code}` requests are sent to the new tv pairing code service.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Checklists

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

